### PR TITLE
Only run the spellcheck when a PR is open

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,6 +1,8 @@
 name: Spellcheck Action
-on: push
-
+on:
+  pull_request:
+    branches:
+      - 'main'
 jobs:
   build:
     name: Spellcheck


### PR DESCRIPTION
Only run the spellcheck when a PR is open to main, not on every push. There's no point spellchecking main after it's been merged, and we want to conserve github actions minutes.