### PR TITLE
Minor fixes to devcontainer and google analytics

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "bundle exec jekyll serve --livereload"
+	"postCreateCommand": "bundle install && bundle exec jekyll serve --livereload"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,4 @@
+<!-- I overrode the minima footer to take out some things that I thought were redundant -->
 <footer class="site-footer h-card">
   <data class="u-url" href="{{ "/" | relative_url }}"></data>
 

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,10 @@
+<!-- Google tag (gtag.js) -->
+<!-- Note: I should remove this once https://github.com/jekyll/minima/pull/825 is released, which fixes GA4 compatibility -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+
+ gtag('config', '{{ site.google_analytics }}');
+</script>


### PR DESCRIPTION
- Make sure the devcontainer does a bundle install before starting Jekyll (assuming it's a fresh environment)
- Override google analytics to support GA4 (https://github.com/jekyll/minima/pull/835)